### PR TITLE
commitsとして取得するDOMのクラス名を変更

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,10 +1,10 @@
 $(function() {
-  var $commits = $("div.commit-links.table-list-cell");
+  var $commits = $("div.commit-links-cell.table-list-cell");
   if($commits.size() > 0) {
-    $commits.append('<div class="commit-links-group button-group commit-compare-list"><input type="radio" name="compare_base" style="margin-right:3px;"><input type="radio" name="compare_to" style="margin-left:3px;"></div>');
+    $commits.append('<div class="commit-links-group btn-group commit-compare-list"><input type="radio" name="compare_base" style="margin-right:3px;"><input type="radio" name="compare_to" style="margin-left:3px;"></div>');
     $commits.eq(0).find('input[type=radio]').click();
 
-    var $compareButton = $('<a>').attr('class','minibutton compare-button').text('Compare Diff');
+    var $compareButton = $('<a>').attr('class','btn btn-sm compare-button').text('Compare Diff');
     $compareButton.click(function() {
       var base = $('input[name=compare_base]:checked').parent().parent().find('a.sha').text().trim();
       var to = $('input[name=compare_to]:checked').parent().parent().find('a.sha').text().trim();
@@ -15,7 +15,13 @@ $(function() {
       })();
       location.href = url;
     });
-    $('div.file-navigation:eq(0)').append($compareButton);
+
+    var isPull = location.href.split('/')[5] == "pull";
+    if (isPull) {
+      $('#commits_bucket').prepend($compareButton);
+    } else {
+      $('div.file-navigation:eq(0)').append($compareButton);
+    }
   }
 });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GithubCompareTool",
-    "version": "0.0.1",
-    "manifest_version": 2,
+    "version": "0.1.0",
+    "manifest_version": 3,
     "description": "Compareボタンを配置します",
     "content_scripts": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "description": "Compareボタンを配置します",
     "content_scripts": [
     {
-      "matches": ["https://github.com/*/*/commits/*"],
+      "matches": ["https://github.com/*/*/commits*"],
       "js": [
               "jquery.min.js",
               "main.js"


### PR DESCRIPTION
試してみたところ、
おそらくgithubのUI変更に伴い（？）、diffのボタンが表示されていないようでしたので
表示されるように変更してみました。(もし自分の使い方が間違っていたらすみません）

よろしくお願いします。
